### PR TITLE
Use "host" configuration for binaries instead of "exec".

### DIFF
--- a/plugin.bzl
+++ b/plugin.bzl
@@ -65,7 +65,7 @@ proto_plugin = rule(
         ),
         "tool": attr.label(
             doc = "The plugin binary. If absent, it is assumed the plugin is built-in to protoc itself and builtin_plugin_name will be used if available, otherwise the plugin name",
-            cfg = "exec",
+            cfg = "host",
             allow_files = True,
             executable = True,
         ),

--- a/protobuf/toolchains.bzl
+++ b/protobuf/toolchains.bzl
@@ -11,7 +11,7 @@ protoc_toolchain = rule(
             doc = "The protocol compiler tool",
             default = "@com_google_protobuf//:protoc",
             executable = True,
-            cfg = "exec",
+            cfg = "host",
         ),
     },
     provides = [platform_common.ToolchainInfo],


### PR DESCRIPTION
"exec" configuration is relatively new and seems to not play well with some rule libraries.